### PR TITLE
Fix libCacheSim/README.md links

### DIFF
--- a/libCacheSim/README.md
+++ b/libCacheSim/README.md
@@ -45,41 +45,41 @@
 ## libCacheSim features 
 * **High performance** - over 20M requests/sec for a realistic trace replay. 
 * **High memory efficiency** - predictable and small memory footprint. 
-* **State-of-the-art algorithms** - eviction algorithms, admission algorithms, prefetching algorithms, sampling techniques, approximate miss ratio computation, see [here](/doc/quickstart_cachesim.md). 
+* **State-of-the-art algorithms** - eviction algorithms, admission algorithms, prefetching algorithms, sampling techniques, approximate miss ratio computation, see [here](./doc/quickstart_cachesim.md). 
 * Parallelism out-of-the-box - uses the many CPU cores to speed up trace analysis and cache simulations. 
-* **The ONLY feature-rich trace analyzer** - all types of trace analysis you need, see [here](/doc/quickstart_traceAnalyzer.md).
-* **Simple API** - easy to build cache clusters, multi-layer caching, etc.; see [here](/doc/API.md).
-* **Extensible** - easy to support new trace types or eviction algorithms; see [here](/doc/advanced_lib_extend.md).
+* **The ONLY feature-rich trace analyzer** - all types of trace analysis you need, see [here](./doc/quickstart_traceAnalyzer.md).
+* **Simple API** - easy to build cache clusters, multi-layer caching, etc.; see [here](./doc/API.md).
+* **Extensible** - easy to support new trace types or eviction algorithms; see [here](./doc/advanced_lib_extend.md).
 ---
 
 <!-- TOC --><a name="supported-algorithms"></a>
 ## Supported algorithms
 cachesim supports the following algorithms:
 ### Eviction algorithms
-* [FIFO](/libCacheSim/cache/eviction/FIFO.c), [LRU](/libCacheSim/cache/eviction/LRU.c), [Clock](/libCacheSim/cache/eviction/Clock.c), [SLRU](/libCacheSim/cache/eviction/SLRU.c)
-* [LFU](/libCacheSim/cache/eviction/LFU.c), [LFU with dynamic aging](/libCacheSim/cache/eviction/LFUDA.c)
-* [ARC](/libCacheSim/cache/eviction/ARC.c), [TwoQ](/libCacheSim/cache/eviction/TwoQ.c)
-* [Belady](/libCacheSim/cache/eviction/Belady.c), [BeladySize](/libCacheSim/cache/eviction/BeladySize.c)
-* [GDSF](/libCacheSim/cache/eviction/cpp/GDSF.cpp)
-* [Hyperbolic](/libCacheSim/cache/eviction/Hyperbolic.c)
-* [LeCaR](/libCacheSim/cache/eviction/LeCaR.c)
-* [Cacheus](/libCacheSim/cache/eviction/Cacheus.c)
-* [LHD](/libCacheSim/cache/eviction/LHD/LHD_Interface.cpp)
-* [LRB](/libCacheSim/cache/eviction/LRB/LRB_Interface.cpp)
-* [GLCache](/libCacheSim/cache/eviction/GLCache/GLCache.c)
-* [WTinyLFU](/libCacheSim/cache/eviction/WTinyLFU.c)
-* [QD-LP](/libCacheSim/cache/eviction/QDLP.c)
-* [S3-FIFO](/libCacheSim/cache/eviction/S3FIFO.c)
-* [Sieve](/libCacheSim/cache/eviction/Sieve.c)
+* [FIFO](./libCacheSim/cache/eviction/FIFO.c), [LRU](./libCacheSim/cache/eviction/LRU.c), [Clock](./libCacheSim/cache/eviction/Clock.c), [SLRU](./libCacheSim/cache/eviction/SLRU.c)
+* [LFU](./libCacheSim/cache/eviction/LFU.c), [LFU with dynamic aging](./libCacheSim/cache/eviction/LFUDA.c)
+* [ARC](./libCacheSim/cache/eviction/ARC.c), [TwoQ](./libCacheSim/cache/eviction/TwoQ.c)
+* [Belady](./libCacheSim/cache/eviction/Belady.c), [BeladySize](./libCacheSim/cache/eviction/BeladySize.c)
+* [GDSF](./libCacheSim/cache/eviction/cpp/GDSF.cpp)
+* [Hyperbolic](./libCacheSim/cache/eviction/Hyperbolic.c)
+* [LeCaR](./libCacheSim/cache/eviction/LeCaR.c)
+* [Cacheus](./libCacheSim/cache/eviction/Cacheus.c)
+* [LHD](./libCacheSim/cache/eviction/LHD/LHD_Interface.cpp)
+* [LRB](./libCacheSim/cache/eviction/LRB/LRB_Interface.cpp)
+* [GLCache](./libCacheSim/cache/eviction/GLCache/GLCache.c)
+* [WTinyLFU](./libCacheSim/cache/eviction/WTinyLFU.c)
+* [QD-LP](./libCacheSim/cache/eviction/QDLP.c)
+* [S3-FIFO](./libCacheSim/cache/eviction/S3FIFO.c)
+* [Sieve](./libCacheSim/cache/eviction/Sieve.c)
 ### Admission algorithms
-* [Adaptsize](/libCacheSim/cache/admission/adaptsize.c)
-* [Bloomfilter](/libCacheSim/cache/admission/bloomfilter.c)
-* [Prob](/libCacheSim/cache/admission/prob.c)
-* [Size](/libCacheSim/cache/admission/size.c)
+* [Adaptsize](./libCacheSim/cache/admission/adaptsize.cpp)
+* [Bloomfilter](./libCacheSim/cache/admission/bloomfilter.c)
+* [Prob](./libCacheSim/cache/admission/prob.c)
+* [Size](./libCacheSim/cache/admission/size.c)
 ### Prefetching algorithms
-* [OBL](/libCacheSim/cache/prefetch/OBL.c)
-* [Mithril](/libCacheSim/cache/prefetch/Mithril.c)
-* [PG](/libCacheSim/cache/prefetch/PG.c)
+* [OBL](./libCacheSim/cache/prefetch/OBL.c)
+* [Mithril](./libCacheSim/cache/prefetch/Mithril.c)
+* [PG](./libCacheSim/cache/prefetch/PG.c)
 ---
 
 


### PR DESCRIPTION
Fixing issue: https://github.com/cacheMon/NSDI24-SIEVE/issues/2

Restated: 
The links in the "libCacheSim features" and "Supported algorithms" point to /NSDI24-SIEVE/blob/main/libCacheSim/<whatever>, but the /NSDI24-SIEVE/blob/ directory doesn't exist.